### PR TITLE
Migrate to Coco

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ categories = ["concurrency"]
 license = "MIT"
 
 [dependencies]
-crossbeam = "0.2"
+coco = "0.1.0"
 parking_lot = "0.3"

--- a/README.org
+++ b/README.org
@@ -1,8 +1,7 @@
 * rculock
-*Please don't use this project at the moment - see [[https://github.com/nivekuil/rculock/issues/1][#1]]*
-A [[https://en.wikipedia.org/wiki/Read-copy-update][read-copy-update]] lock using [[https://aturon.github.io/blog/2015/08/27/epoch/][epoch-based reclamation]] through [[https://github.com/aturon/crossbeam][crossbeam]].
+A [[https://en.wikipedia.org/wiki/Read-copy-update][read-copy-update]] lock using [[https://aturon.github.io/blog/2015/08/27/epoch/][epoch-based reclamation]] through [[https://github.com/stjepang/coco][coco]].
 
-The API is similar to =std::sync::RwLock=. Reads are lock-free and never block.  Writes update the data protected by the lock only when the write guard is dropped.
+The API is similar to =std::sync::RwLock=.  Readers are lock-free and can exist concurrently with a writer, which updates the data protected by the lock only when the write guard is dropped.
 
 See [[https://docs.rs/rculock/][documentation]] for more details.
 

--- a/README.org
+++ b/README.org
@@ -1,9 +1,8 @@
 * rculock
-A [[https://en.wikipedia.org/wiki/Read-copy-update][read-copy-update]] lock using [[https://github.com/aturon/crossbeam][crossbeam]].
+*Please don't use this project at the moment - see [[https://github.com/nivekuil/rculock/issues/1][#1]]*
+A [[https://en.wikipedia.org/wiki/Read-copy-update][read-copy-update]] lock using [[https://aturon.github.io/blog/2015/08/27/epoch/][epoch-based reclamation]] through [[https://github.com/aturon/crossbeam][crossbeam]].
 
-The API is similar to =std::sync::RwLock=.  Readers are lock-free and can exist concurrently with a writer, which updates the data protected by the lock only when the write guard is dropped.
-
-This crate should currently be usable, but isn't a very efficient implementation (see [[https://github.com/nivekuil/rculock/issues/1][#1]]).
+The API is similar to =std::sync::RwLock=. Reads are lock-free and never block.  Writes update the data protected by the lock only when the write guard is dropped.
 
 See [[https://docs.rs/rculock/][documentation]] for more details.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,15 +22,15 @@
 //! ```
 
 extern crate parking_lot;
-extern crate crossbeam;
+extern crate coco;
+use std::mem::drop;
 use std::sync::Arc;
-use std::sync::atomic::Ordering::Relaxed;
 use std::ops::{Deref, DerefMut};
-use crossbeam::mem::epoch::{self, Atomic, Owned};
+use coco::epoch::{self, Atomic, Garbage};
 use parking_lot::{Mutex, MutexGuard};
 
 #[derive(Debug)]
-pub struct RcuLock<T: Clone> {
+pub struct RcuLock<T> {
     /// The resource protected by the lock, behind an `Atomic` for atomic stores,
     /// and an Arc to hand the resource out to readers without fear of memory leaks.
     inner: Atomic<Arc<T>>,
@@ -39,25 +39,27 @@ pub struct RcuLock<T: Clone> {
     /// `RcuLock`, write to it, and then store their individual changes to the master `RcuLock`.
     /// Acquired on `write()` and released when `RcuGuard` is dropped.
     write_lock: Mutex<()>,
+    /// Epoch-based garbage collector to free our Arc<T> once there's no more
+    /// references to it.
+    garbage: Garbage,
 }
 
-impl<T: Clone> RcuLock<T> {
+impl<T: Clone + Send + 'static> RcuLock<T> {
     /// Create a new RcuLock.
     pub fn new(target: T) -> RcuLock<T> {
-        let inner = Atomic::null();
-        let arc = Owned::new(Arc::new(target));
-        inner.store(Some(arc), Relaxed);
+        let inner = Atomic::from_box(Box::new(Arc::new(target)), 0);
         RcuLock {
             inner: inner,
             write_lock: Mutex::new(()),
+            garbage: Garbage::new(),
         }
     }
 
     /// Acquire a read handle to the `RcuLock`.  This operation never blocks.
     pub fn read(&self) -> Arc<T> {
-        let epoch = epoch::pin();
-        let inner = self.inner.load(Relaxed, &epoch);
-        Arc::clone(&inner.unwrap())
+        epoch::pin(|pin| {
+            self.inner.load(pin).unwrap().clone()
+        })
     }
 
     /// Acquire an exclusive write handle to the `RcuLock`, protected by an `RcuGuard`.
@@ -67,8 +69,9 @@ impl<T: Clone> RcuLock<T> {
     /// Clones the data protected by the `RcuLock`, which can be expensive.
     pub fn write(&self) -> RcuGuard<T> {
         let guard = self.write_lock.lock();
-        let epoch = epoch::pin();
-        let data = T::clone(&self.inner.load(Relaxed, &epoch).unwrap());
+        let data = epoch::pin(|pin| {
+            T::clone(self.inner.load(pin).unwrap())
+        });
         RcuGuard {
             lock: self,
             data: data,
@@ -77,19 +80,28 @@ impl<T: Clone> RcuLock<T> {
     }
 }
 
-pub struct RcuGuard<'a, T: 'a + Clone> {
+impl<T> Drop for RcuLock<T> {
+    fn drop(&mut self) {
+        epoch::pin(|pin| {
+            let inner = self.inner.load(pin);
+            drop(unsafe { Box::from_raw(inner.as_raw()) });
+        })
+    }
+}
+
+pub struct RcuGuard<'a, T: Clone + Send + 'static> {
     lock: &'a RcuLock<T>,
     data: T,
     _guard: MutexGuard<'a, ()>,
 }
 
-impl<'a, T: Clone> DerefMut for RcuGuard<'a, T> {
+impl<'a, T: Clone + Send + 'static> DerefMut for RcuGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.data
     }
 }
 
-impl<'a, T: Clone> Deref for RcuGuard<'a, T> {
+impl<'a, T: Clone + Send + 'static> Deref for RcuGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.data
@@ -97,9 +109,14 @@ impl<'a, T: Clone> Deref for RcuGuard<'a, T> {
 }
 
 /// On drop, atomically store the data back into the owning `RcuLock`.
-impl<'a, T: Clone> Drop for RcuGuard<'a, T> {
+impl<'a, T: Clone + Send + 'static> Drop for RcuGuard<'a, T> {
     fn drop(&mut self) {
-        let data = Owned::new(Arc::new(self.data.clone()));
-        self.lock.inner.store(Some(data), Relaxed)
+        let data = Box::new(Arc::new(self.data.clone()));
+        epoch::pin(|pin| {
+            let old_data = self.lock.inner.swap_box(data, 0, pin);
+            unsafe {
+                self.lock.garbage.defer_drop(old_data.as_raw(), 1, pin);
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes #1 

Coco implements an epoch GC which calls destructors - this therefore shouldn't leak memory, and is properly lock-free for reads.

See crossbeam-rs/crossbeam#134 for some discussion of Coco's epoch GC.